### PR TITLE
Use production as a default for node env

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const dotenv = require('dotenv');
 
-const nodeEnv = () => process.env.NODE_ENV || 'development';
+const nodeEnv = () => process.env.NODE_ENV || 'production';
 const isDev = () => nodeEnv() === 'development';
 
 const isFunction = /* #__PURE__ */ predicate => typeof predicate === 'function';

--- a/test/dotenv.test.js
+++ b/test/dotenv.test.js
@@ -255,3 +255,15 @@ describe('variable substitution', () => {
     });
   });
 });
+
+test('to default node environment to production', () => {
+  delete process.env.NODE_ENV;
+
+  const env = dotenv.config(options);
+
+  expect(env).toEqual({
+    FOO: 'foo-env',
+    BAZ: 'baz-env-production',
+    XYZ: undefined,
+  });
+});

--- a/test/fixtures/.env.production
+++ b/test/fixtures/.env.production
@@ -1,0 +1,1 @@
+BAZ=baz-env-production


### PR DESCRIPTION
I think we should default the environment to production, because of security concerns. Users often set a DEBUG environment variable to true for the development and staging environment. This DEBUG flag will enable debug features such as detail error reporting when set.

If a user of the package messes up and forget's to set the NODE_ENV variable to production in the production environment, an attacker might be able to retrieve the debug information and abuse the gained knowledge.

Nice functional code BTW ;)